### PR TITLE
Adding link to talks.ruby.org.nz

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # NZ Ruby Talks
 
 Talks given at NZ Ruby groups, powered by [Middleman](http://middlemanapp.com).
+You can view the talks at [talks.ruby.org.nz](http://talks.ruby.org.nz)
 
 ## Development environment
 


### PR DESCRIPTION
Just a little link to where the posts are posted to...
