### PR TITLE
Upcoming is calculated based on site generation date

### DIFF
--- a/lib/talk.rb
+++ b/lib/talk.rb
@@ -14,7 +14,7 @@ class Talk < SimpleDelegator
   end
 
   def upcoming?
-    data.upcoming
+    date > Time.now
   end
 
   def self.all(resources)

--- a/source/talks/2013/10-17-enumerable-in-ten-minutes.md.erb
+++ b/source/talks/2013/10-17-enumerable-in-ten-minutes.md.erb
@@ -3,7 +3,6 @@ title: Enumerable in 10 Minutes
 layout: talk
 author: Pete Nicholls
 venue: Christchurch Ruby
-upcoming: true
 intro: Rubyisms with a mesmerizing mixin.
 ---
 

--- a/source/talks/2013/10-17-metaprogramming-with-ruby.md.erb
+++ b/source/talks/2013/10-17-metaprogramming-with-ruby.md.erb
@@ -3,7 +3,6 @@ title: Metaprogramming with Ruby
 layout: talk
 author: Philip Arndt
 venue: Christchurch Ruby
-upcoming: true
 intro: An introduction to metaprogramming with Ruby.
 ---
 

--- a/source/talks/2013/10-17-quick-and-dirty-rails.md
+++ b/source/talks/2013/10-17-quick-and-dirty-rails.md
@@ -3,7 +3,6 @@ title: Quick and Dirty Rails
 layout: talk
 author: Daniel Fone
 venue: Christchurch Ruby
-upcoming: true
 intro: Putting the fun back in dysfunctional.
 ---
 


### PR DESCRIPTION
This is a little more dynamic than setting a flag in the front-matter
since it will be updated every time the site is generated.
