### PR TITLE
Using ffi 1.9.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       sass (~> 3.1)
     execjs (1.4.0)
       multi_json (~> 1.0)
-    ffi (1.9.1)
+    ffi (1.9.3)
     fssm (0.2.10)
     haml (4.0.3)
       tilt


### PR DESCRIPTION
Looks like 1.9.1 version of ffi has been pulled.  This is just a bundle update

http://rubygems.org/gems/ffi
